### PR TITLE
Python 2.7 compatibility fixes

### DIFF
--- a/doxieapi/__init__.py
+++ b/doxieapi/__init__.py
@@ -1,1 +1,2 @@
+from __future__ import absolute_import
 from .api import DoxieScanner

--- a/doxieapi/__main__.py
+++ b/doxieapi/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 
 from .api import DoxieScanner

--- a/doxieapi/api.py
+++ b/doxieapi/api.py
@@ -1,15 +1,12 @@
+from __future__ import with_statement
+from __future__ import absolute_import
+import install_aliases  # noqa # pylint: disable=unused-import
+
 import os
 import time
 import json
-try:
-    from configparser import ConfigParser
-except ImportError:
-    # We're on Python 2
-    from ConfigParser import ConfigParser
-try:
-    from urllib.parse import urlparse, urlunparse, urljoin
-except ImportError:
-    from urlparse import urlparse, urlunparse, urljoin
+from configparser import ConfigParser
+from urllib.parse import urlparse, urlunparse, urljoin
 
 import requests
 
@@ -20,7 +17,7 @@ DOXIE_SSDP_SERVICE = "urn:schemas-getdoxie-com:device:Scanner:1"
 # Scans are downloaded in chunks of this many bytes:
 DOWNLOAD_CHUNK_SIZE = 1024*8
 
-class DoxieScanner:
+class DoxieScanner(object):
     url = None
     username = "doxie" # This is always the same according to API docs
     password = None

--- a/doxieapi/api.py
+++ b/doxieapi/api.py
@@ -200,9 +200,8 @@ class DoxieScanner(object):
         url = self._api_url(path)
         response = self._get_url(url, stream=True)
         output_path = os.path.join(output_dir, os.path.basename(path))
-        if os.path.isfile(output_path):
-            raise FileExistsError(output_path)
-        with open(output_path, 'wb') as f:
+        fd = os.open(output_path, os.O_CREAT | os.O_EXCL)
+        with os.fdopen(fd, 'wb') as f:
             for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
                 f.write(chunk)
         return output_path

--- a/doxieapi/ssdp.py
+++ b/doxieapi/ssdp.py
@@ -12,11 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from __future__ import absolute_import
+import install_aliases  # noqa # pylint: disable=unused-import
+
+from http.client import HTTPResponse
 import socket
-try:
-    from http.client import HTTPResponse
-except ImportError:
-    from httplib import HTTPResponse
 
 class SSDPResponse(object):
     def __init__(self, sock):

--- a/install_aliases.py
+++ b/install_aliases.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+"""
+This file sets up aliases for the standard library via the future module.
+"""
+
+from future import standard_library
+standard_library.install_aliases()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[bdist_wheel]
+universal=1
+
+[pylint.IMPORTS]
+known-standard-library = install_aliases
+
+[pylint.TYPECHECK]
+disable=useless-object-inheritance

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,11 @@ setup(
     version = "0.0.2",
     packages = find_packages(),
 
-    install_requires = ['requests'],
+    install_requires = [
+        'configparser;python_version<"3.2"',
+        'future',
+        'requests',
+    ],
 
     author = "Dave Arter",
     author_email = "pypi@davea.me",


### PR DESCRIPTION
This PR implements remaining fixes for compatibility with Python 2.7.

* Use the `future` package, and `configparser` on versions older than 3.2 for better cross-version support.
* New-style objects were defined where appropriate, and pylint set to ignore this for Python 3 instances.
* For required behaviour, we use `with_statement`, `absolute_import` and `print_function` from `__future__`.
* We also set bdist to produce a universal wheel when building packages.

An additional change has been made to properly handle "file exists" conditions with Python 2.

Fixes: https://github.com/davea/doxieapi/issues/4.