### PR TITLE
Drop Python <3.4 support

### DIFF
--- a/doxieapi/api.py
+++ b/doxieapi/api.py
@@ -1,15 +1,8 @@
 import os
 import time
 import json
-try:
-    from configparser import ConfigParser
-except ImportError:
-    # We're on Python 2
-    from ConfigParser import ConfigParser
-try:
-    from urllib.parse import urlparse, urlunparse, urljoin
-except ImportError:
-    from urlparse import urlparse, urlunparse, urljoin
+from configparser import ConfigParser
+from urllib.parse import urlparse, urlunparse, urljoin
 
 import requests
 
@@ -141,8 +134,8 @@ class DoxieScanner:
         config.read(config_path)
         try:
             self.password = config[self.mac]['password']
-        except KeyError:
-            raise Exception("Couldn't find password for Doxie {} in {}".format(self.mac, config_path))
+        except KeyError as err:
+            raise Exception("Couldn't find password for Doxie {} in {}".format(self.mac, config_path)) from err
 
     @property
     def firmware(self):

--- a/doxieapi/ssdp.py
+++ b/doxieapi/ssdp.py
@@ -13,12 +13,10 @@
 #   limitations under the License.
 
 import socket
-try:
-    from http.client import HTTPResponse
-except ImportError:
-    from httplib import HTTPResponse
+from http.client import HTTPResponse
 
-class SSDPResponse(object):
+
+class SSDPResponse:
     def __init__(self, sock):
         r = HTTPResponse(sock)
         r.begin()

--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,5 @@ setup(
     license = "LICENSE.txt",
     keywords = "doxie document scanner",
     url = "https://github.com/davea/doxieapi/",
+    python_requires = ">=3.4",
 )


### PR DESCRIPTION
An attempt was made in https://github.com/davea/doxieapi/pull/5 to improve the Python 2.7 compatibility of this package.

For future development I would recommend we drop support for Python < 3.4 as these are out of support, and no new projects should be using those versions.

This PR removes Python 2 compatibility code where applicable, and sets a hard requirement for Python >= 3.4.

Fixes: https://github.com/davea/doxieapi/issues/4.